### PR TITLE
Fix auth client path and token key

### DIFF
--- a/frontend/book-quotes/auth.interceptor.ts
+++ b/frontend/book-quotes/auth.interceptor.ts
@@ -5,7 +5,8 @@ import { Observable } from 'rxjs';
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        const token = localStorage.getItem('jwtToken');
+        // Tokens are stored under the key 'token' by the login component.
+        const token = localStorage.getItem('token');
         if (token) {
             const cloned = req.clone({
                 setHeaders: {

--- a/frontend/book-quotes/auth.service.ts
+++ b/frontend/book-quotes/auth.service.ts
@@ -4,11 +4,13 @@ import { Router } from '@angular/router';
 
 @Injectable({ providedIn: 'root'})
 export class AuthService{
-  private apiUrl = "https://localhost:2424"; 
+  private apiUrl = "https://localhost:2424";
   constructor(private http: HttpClient, private router: Router) { }
 
   login(credentials: { username: string, password: string }) {
-    return this.http.post(`${this.apiUrl}/login`, credentials);
+    // The backend AuthController expects requests at /auth/login
+    // rather than /login, so adjust the path accordingly.
+    return this.http.post(`${this.apiUrl}/auth/login`, credentials);
   }
 
   logout() {


### PR DESCRIPTION
## Summary
- fix login path to call `/auth/login`
- have HTTP interceptor use the same localStorage key as the login page

## Testing
- `npm test --silent`
